### PR TITLE
Add SpatialMovingAverageModel to error models

### DIFF
--- a/src/models/error_model.jl
+++ b/src/models/error_model.jl
@@ -231,6 +231,18 @@ prec(model::AbstractErrorModel)= model.Ω
 prec(model::Independent)= Diagonal(model.ω)
 
 """
+    spatial(model)
+
+Retrieve spatial dependence parameter of error model
+
+#### Arguments
+  - `model::AbstractErrorModel` : error model
+"""
+spatial(model::AbstractErrorModel)= nothing
+spatial(model::SpatialErrorModel)= model.ρ
+spatial(model::SpatialMovingAverageModel)= model.λ
+
+"""
     init_ρ!(ρ, ε, W, groups, ρ_max)
 
 Initialize spatial dependence parameter `ρ` using spatial lag regression of

--- a/src/models/error_model.jl
+++ b/src/models/error_model.jl
@@ -245,8 +245,12 @@ residuals `ε`, storing the result in `ρ`.
 #### Returns
   - `ρ::AbstractVector` : spatial dependence
 """
-function init_ρ!(ρ::AbstractVector, ε::AbstractMatrix, W::AbstractMatrix, 
-                groups::AbstractVector, ρ_max::Real)
+function init_ρ!(   ρ::AbstractVector, 
+                    ε::AbstractMatrix, 
+                    W::AbstractMatrix, 
+                    groups::AbstractVector, 
+                    ρ_max::Real
+                )
     # squared residuals
     ε_sq= ε * transpose(ε)
 
@@ -284,8 +288,11 @@ spatial weights `W`, storing the result in `G`.
 #### Returns
   - `G::AbstractMatrix` : spatial lag polynomial  
 """
-function spatial_polynomial!(G::AbstractMatrix, ρ::AbstractVector, 
-                                W::AbstractMatrix, groups::AbstractVector)
+function spatial_polynomial!(   G::AbstractMatrix, 
+                                ρ::AbstractVector, 
+                                W::AbstractMatrix, 
+                                groups::AbstractVector
+                            )
     idx= 1
     @inbounds @fastmath for i in 1:length(ρ)
         rng= idx:idx+groups[i]-1


### PR DESCRIPTION
Add a spatial moving average model type to the error models, such that we can handle local spillover effects